### PR TITLE
Correct minor text error in explore.html to enhance clarity by specif…

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -455,7 +455,7 @@
       <p></p>
       <h3 class="feature-headline">Article Digest: AI-Curated Article Summaries</h3>
       <p class="feature-description">
-        A quick, digestible content format that pulls contextual summaries from source article; giving users the gist without commiting to a full read. 
+        A quick, digestible content format that pulls contextual summaries from the source article; giving users the gist without commiting to a full read. 
         That said, Digests were intentionally designed to include a clear pathway to the full article, 
         for those who wanted to dive deeper into the topic.
       </p>


### PR DESCRIPTION
…ying "the source article" instead of "source article" in the article digest description.