### PR TITLE
Enhance GIF handling in index.js for mobile work page by skipping opt…

### DIFF
--- a/index.js
+++ b/index.js
@@ -409,8 +409,15 @@ document.addEventListener('DOMContentLoaded', function() {
   function optimizeGifs() {
     const gifs = document.querySelectorAll('img[src$=".gif"], img[src*=".gif"]');
     
-    // Check if we're on mobile - if so, skip the complex optimizations
+    // Check if we're on mobile - if so, skip GIF optimizations entirely for work.html
     const isMobile = window.innerWidth <= 768 || /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    const isWorkPage = window.location.pathname.includes('work.html');
+    
+    // Skip all GIF processing on mobile work page since we use static images
+    if (isMobile && isWorkPage) {
+      console.log('Mobile work page detected - skipping all GIF optimizations, using static images only');
+      return;
+    }
     
     gifs.forEach(gif => {
       // Always add loading="lazy" if not already present
@@ -537,6 +544,13 @@ document.addEventListener('DOMContentLoaded', function() {
   function initInteractiveGifs() {
     const interactiveGifs = document.querySelectorAll('.gif-interactive');
     const isMobile = window.innerWidth <= 768;
+    const isWorkPage = window.location.pathname.includes('work.html');
+    
+    // Skip interactive GIF processing on mobile work page since we use static images
+    if (isMobile && isWorkPage) {
+      console.log('Mobile work page detected - skipping interactive GIF processing, using static images only');
+      return;
+    }
     
     interactiveGifs.forEach(gif => {
       const gifSrc = gif.getAttribute('data-gif-src');

--- a/styles.css
+++ b/styles.css
@@ -1038,19 +1038,7 @@ img[src*=".gif"] {
   box-sizing: border-box;
 }
 
-/* Mobile-specific GIF fixes */
-@media (max-width: 768px) {
-  img[src$=".gif"], 
-  img[src*=".gif"] {
-    width: 100% !important;
-    max-width: 100% !important;
-    min-width: 0;
-    flex-shrink: 1;
-    height: auto;
-    object-fit: cover;
-    overflow: hidden;
-  }
-}
+/* Mobile-specific GIF fixes removed - mobile uses static images only */
 
 /* Floating Toolbar */
 .floating-logo {


### PR DESCRIPTION
…imizations and processing, ensuring static images are used instead. Remove mobile-specific GIF styles from styles.css to reflect this change.